### PR TITLE
Add additional error handling

### DIFF
--- a/activity/mySQLFetch/activity.go
+++ b/activity/mySQLFetch/activity.go
@@ -112,7 +112,11 @@ func (a *MyActivity) Eval(context activity.Context) (done bool, err error) {
 
 	sNo := 0
 
-	rows, _ := db.Query(ivquery)
+	rows, queryerr := db.Query(ivquery)
+	
+	if queryerr != nil {
+		panic(queryerr.Error())
+	}
 
 	cols, _ := rows.Columns()
 	for rows.Next() {


### PR DESCRIPTION
If for some reason the MySQL query returns an error the rest of the code will not work properly, so you want to catch the error and return a panic before executing the rest of the code